### PR TITLE
Don't throw an error when the user deletes entire input

### DIFF
--- a/angular-money-directive.js
+++ b/angular-money-directive.js
@@ -29,6 +29,9 @@ angular.module('fiestah.money', [])
 
 
     ngModelCtrl.$parsers.push(function (value) {
+      if (value === undefined) {
+        value = '';
+      }
       // Handle leading decimal point, like ".5"
       if (value.indexOf('.') === 0) {
         value = '0' + value;

--- a/test/angular-money-directive.spec.js
+++ b/test/angular-money-directive.spec.js
@@ -39,7 +39,13 @@ describe('angular-money-directive', function () {
 
     it('displays an empty string in the view by default', function () {
       expect(inputEl.val()).to.equal('');
-    })
+    });
+
+    it("displays an empty string when the user deletes entire input", function () {
+      setValue(undefined);
+      expect(scope.model.price).to.equal(null);
+      expect(form.price.$valid).to.be.true;
+    });
 
     it('accepts in-range values', function () {
       setValue('50.4');


### PR DESCRIPTION
In Chrome & Firefox (didn't test anything else) the directive receives an undefined value when a user deletes/backspaces the entire input clear.  This was causing errors to be thrown in the console.
