### PR TITLE
Ensure rounded value uses fixed-point notation with precision

### DIFF
--- a/angular-money-directive.js
+++ b/angular-money-directive.js
@@ -129,7 +129,7 @@ angular.module('fiestah.money', [])
       ngModelCtrl.$parsers.push(function (value) {
         if (value) {
           // Save with rounded value
-          lastValidValue = round(value);
+          lastValidValue = round(value).toFixed(precision);
 
           return lastValidValue;
         } else {


### PR DESCRIPTION
If an integer is entered into a field using the money directive, the field will display a floating point number rounded to the specified precision, but the number in the model will be an integer. This caused problems with server-side validation in my case where a floating point number was expected. After the value is rounded, ensure the value is a floating point number in the model.