### PR TITLE
Support for 0 in a background model update.

### DIFF
--- a/src/angular-money-directive.js
+++ b/src/angular-money-directive.js
@@ -150,7 +150,7 @@ angular.module('fiestah.money', [])
     });
 
     ngModelCtrl.$formatters.push(function (value) {
-      if (value) {
+      if (isDefined(value) && isNumber(value)) {
         return isPrecisionValid() && isValueValid(value) ?
           formatPrecision(value) : value;
       } else {

--- a/src/angular-money-directive.js
+++ b/src/angular-money-directive.js
@@ -150,7 +150,7 @@ angular.module('fiestah.money', [])
     });
 
     ngModelCtrl.$formatters.push(function (value) {
-      if (isDefined(value) && isNumber(value)) {
+      if (isDefined(value)) {
         return isPrecisionValid() && isValueValid(value) ?
           formatPrecision(value) : value;
       } else {

--- a/test/angular-money-directive.spec.js
+++ b/test/angular-money-directive.spec.js
@@ -55,6 +55,18 @@ describe('angular-money-directive', function () {
       expect(form.price.$valid).to.be.true;
     });
   });
+  
+  describe('when ngModel is set to a valid zero (0) value', function () {
+    beforeEach(function () {
+      scope.model.price = 0;
+      setupDirective();
+    });
+
+    it('displays the formatted value', function () {
+      expect(inputEl.val()).to.equal('0.00');
+      expect(form.price.$valid).to.be.true;
+    });
+  });
 
   describe('when ngModel is set to an invalid value', function () {
     beforeEach(function () {


### PR DESCRIPTION
Modified the model formatter to check to see if the value is defined and if the value is a number instead of just checking for if(value).  Since 0 could be a valid value for the model, this will allow a 0 to be properly formatted.